### PR TITLE
Add Werkzeug library

### DIFF
--- a/python-flask-api/requirements.txt
+++ b/python-flask-api/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.1.2
 requests==2.31.0
+Werkzeug==2.2.2
 ptvsd==4.3.2 # Required for debugging.
 google-cloud-logging


### PR DESCRIPTION
Currently, an issue arises during the deployment of the application on Cloud run due to the recent release of Werkzeug 3 (now it's 3.0.2) utilizied in the Flask Library.

The log indicates an ImportError, specifically regarding the inability to import the 'url_quote' name from 'werkzeug.urls':
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/site-packages/werkzeug/urls.py)

To address this, I have specify the Werkzeug library v2.2.2 for Flask v2.1.2 that currently used to resolve the issue. 
I Hope it's helpful, thanks.